### PR TITLE
Removed bad packages from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,15 +7,12 @@
   <maintainer email="avangipuram@berkeley.edu">ashwin</maintainer>
   <license>TODO: License declaration</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <build_depend>rclpy</build_depend>
   <build_depend>teleop_twist_keyboard</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>razor_imu_9dof</exec_depend>
   <exec_depend>sub_interfaces</exec_depend>
   <exec_depend>teleop_twist_keyboard</exec_depend>
 


### PR DESCRIPTION
Removing razor_imu since we aren't using it, and removing ament_python as it shouldn't be a buildtool depend according to https://github.com/ros2/ros2cli/pull/428.